### PR TITLE
Bump node engines for node: namespace support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stdout-stderr": "^0.1.9"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^14.18 || ^16.13 || >=18"
   },
   "files": [
     "/npm-shrinkwrap.json",


### PR DESCRIPTION
This pr bumps node support to LTS versions and drops support for 12 which is EOL
Minor version choices are to ensure we get node: namespace supporting versions of node. 