### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,7 @@ Adobe Developer cli usage telemetry
 [![Github Issues](https://img.shields.io/github/issues/adobe/aio-cli-plugin-telemetry.svg)](https://github.com/adobe/aio-cli-plugin-telemetry/issues)
 [![Github Pull Requests](https://img.shields.io/github/issues-pr/adobe/aio-cli-plugin-telemetry.svg)](https://github.com/adobe/aio-cli-plugin-telemetry/pulls) 
 
-<!-- toc -->
-* [Usage](#usage)
-* [Commands](#commands)
-<!-- tocstop -->
-# Usage
-<!-- usage -->
-```sh-session
-$ npm install -g @adobe/aio-cli-plugin-telemetry
-$ aio COMMAND
-running command...
-$ aio (--version)
-@adobe/aio-cli-plugin-telemetry/1.0.1 darwin-arm64 node-v16.16.0
-$ aio --help [COMMAND]
-USAGE
-  $ aio COMMAND
-...
-```
-<!-- usagestop -->
+
 # Commands
 <!-- commands -->
 * [`aio telemetry yes`](#aio-telemetry-yes)

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,18 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+/*
+Copyright 2022 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const oclif = require('@oclif/core')
+
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jest-fetch-mock": "^3.0.0",
     "jest-junit": "^13.0.0",
     "jest-plugin-fs": "^2.9.0",
-    "oclif": "^3.0.1",
+    "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9"
   },
   "engines": {
@@ -103,7 +103,7 @@
     ]
   },
   "scripts": {
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "lint": "eslint src test",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
-    "topicSeparator": ":",
+    "topicSeparator": " ",
     "devPlugins": [
       "@oclif/plugin-help"
     ],


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases. 