### PR TITLE
fix: ACNA-2806 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ DESCRIPTION
   Allow the cli to collect anonymous usage data
 ```
 
-_See code: [src/commands/telemetry/index.ts](https://github.com/adobe/aio-cli-plugin-telemetry/blob/v2.0.1/src/commands/telemetry/index.ts)_
+_See code: [src/commands/telemetry/index.js](https://github.com/adobe/aio-cli-plugin-telemetry/blob/v2.0.1/src/commands/telemetry/index.js)_
 <!-- commandsstop -->
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "splunk-logging": "^0.11.1"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.2",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "eslint": "^8.56.0",
     "eslint-config-oclif": "^1",
     "eslint-config-standard": "^17.1.0",
@@ -32,8 +32,7 @@
     "jest-junit": "^13.0.0",
     "memfs": "^4.6.0",
     "oclif": "^4.3.6",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.3.3"
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #23 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
