### PR TITLE
fix: remove node-fetch, use built-in fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "ci-info": "^4.0.0",
     "debug": "^4.1.1",
     "inquirer": "^8.2.1",
-    "node-fetch": "^2.6.7",
     "os-name": "^4.0.1",
     "splunk-logging": "^0.11.1"
   },
@@ -28,7 +27,6 @@
     "eslint-plugin-standard": "^4.0.1",
     "execa": "^4.0.2",
     "jest": "^29",
-    "jest-fetch-mock": "^3.0.0",
     "jest-junit": "^13.0.0",
     "memfs": "^4.6.0",
     "oclif": "^4.3.6",

--- a/src/telemetry-lib.js
+++ b/src/telemetry-lib.js
@@ -9,7 +9,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fetch = require('node-fetch')
 const config = require('@adobe/aio-lib-core-config')
 const osName = require('os-name')
 const inquirer = require('inquirer')

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-const fetch = require('node-fetch')
 const inquirer = require('inquirer')
 const config = require('@adobe/aio-lib-core-config')
 
@@ -28,7 +27,7 @@ const mockPackageJson = {
 
 describe('hook interfaces', () => {
   beforeEach(() => {
-    fetch.mockReset()
+    global.setFetchMock()
   })
 
   test('command-error', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-const fetch = require('node-fetch')
 const TheCommand = require('../src/commands/telemetry')
 const { stdout } = require('stdout-stderr')
 
@@ -19,9 +18,8 @@ jest.mock('inquirer')
 let command
 
 beforeEach(() => {
-  fetch.resetMocks()
   command = new TheCommand([])
-  fetch.mockResponseOnce('ok')
+  global.setFetchMock()
 })
 
 test('exports a run function', async () => {

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -16,8 +16,12 @@ const { vol } = require('memfs')
 jest.setTimeout(3000)
 jest.useFakeTimers()
 
-const fetch = require('jest-fetch-mock')
-jest.setMock('node-fetch', fetch)
+global.setFetchMock = (ok = true, mockData = {}) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    json: () => ok ? Promise.resolve(mockData) : Promise.reject(mockData)
+  })
+}
 
 vol.reset()
 


### PR DESCRIPTION
## Motivation and Context

node-fetch@v2's dependencies use the built in punycode module, which is deprecated in node-22, and prints out a deprecation warning.

## How Has This Been Tested?

- npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.