### PR TITLE
fix(telemetry): flush terminal events immediately so error telemetry is delivered

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Example shape of the metric payload:
     "value": 1,
     "timestamp": 1673404918437,
     "attributes": {
-      "eventType": "postrun",
+      "eventName": "postrun",
       "eventData": "{}",
       "cliVersion": "@adobe/aio-cli@11.0.2",
       "clientId": 264421030538,

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ AIO_TELEMETRY_DISABLED=yes aio app deploy
 
 Telemetry is **best-effort**: events are not persisted when the proxy is down or the network fails.
 
-On **`postrun`**, any in-memory metrics from earlier hooks in the same command are merged with the `postrun` metric and the combined batch is handed off to a **fire-and-forget detached subprocess** (`src/flush-worker.js`). The parent CLI spawns the worker and immediately `unref()`s it, so the CLI can exit without waiting for the HTTP POST. If the POST fails (network error or non-2xx response), the batch is dropped; telemetry must not block or slow normal CLI use.
+A flush happens on a **terminal event** — `postrun` (command succeeded), `command-error` (command threw), or `command-not-found`. oclif runs `postrun` only on success, so `command-error`/`command-not-found` must flush on their own; otherwise error telemetry (the most valuable signal) would be buffered and silently dropped on exit. On a terminal event, any in-memory metrics from earlier hooks in the same command are merged with the terminal metric and the combined batch is handed off to a **fire-and-forget detached subprocess** (`src/flush-worker.js`). The parent CLI spawns the worker and immediately `unref()`s it, so the CLI can exit without waiting for the HTTP POST. If the POST fails (network error or non-2xx response), the batch is dropped; telemetry must not block or slow normal CLI use.
 
-Non-`postrun` events (for example `command-error`, `telemetry-notice`) are held in an **in-memory buffer** until that flush. If the process exits before `postrun` (crash, `SIGKILL`), buffered events are lost. The buffer is cleared when telemetry is disabled or when `init` runs again (new command session).
+Non-terminal events (for example `telemetry-notice`) are held in an **in-memory buffer** until the next terminal event flushes them. If the process exits before any terminal event (crash, `SIGKILL`), buffered events are lost. The buffer is cleared when telemetry is disabled or when `init` runs again (new command session).
 
 ## Agent detection
 

--- a/src/telemetry-lib.js
+++ b/src/telemetry-lib.js
@@ -29,8 +29,14 @@ let isDisabledForCommand = false
 /** Metrics for non-terminal events in the current command; merged into the POST on a terminal event. */
 const pendingCommandMetrics = []
 
-/** Events after which oclif does not run `postrun`; each triggers an immediate flush. */
+/** Events with no `postrun` after them; each flushes immediately so error telemetry isn't lost. */
 const TERMINAL_EVENTS = ['postrun', 'command-error', 'command-not-found']
+
+/** Events that mean the command did not succeed (so `commandSuccess` is false). */
+const FAILED_COMMAND_EVENTS = ['command-error', 'command-not-found']
+
+/** Set by `command-not-found` so we can drop the host's immediate `command-error` rethrow of the same typo. */
+let commandNotFoundFired = false
 
 /**
  * Detects GitHub Copilot Chat on PATH via the extension id in globalStorage paths (any OS path separator).
@@ -215,7 +221,7 @@ async function trackEvent (eventType, rawEventData = {}) {
         command: prerunEvent.command,
         commandDuration: timestamp - prerunEvent.start,
         commandFlags: prerunEvent.flags.toString(),
-        commandSuccess: eventType !== 'command-error',
+        commandSuccess: !FAILED_COMMAND_EVENTS.includes(eventType),
         nodeVersion: process.version,
         osNameVersion,
         invocation_context: /* istanbul ignore next */ invocationContext.isAgent ? 'agent' : 'human',
@@ -223,13 +229,18 @@ async function trackEvent (eventType, rawEventData = {}) {
       }
     }
 
-    // `postrun` fires after a command completes successfully. `command-error` and
-    // `command-not-found` are *terminal*: oclif does NOT run `postrun` after them, so if we
-    // only flushed on `postrun` these (the most valuable signal) would be buffered and silently
-    // dropped on exit. Flush on any terminal event so error telemetry is actually delivered.
-    const isTerminalEvent = TERMINAL_EVENTS.includes(eventType)
-    if (!isTerminalEvent) {
+    // Non-terminal events buffer; terminal events flush (oclif runs no postrun after error/not-found).
+    if (!TERMINAL_EVENTS.includes(eventType)) {
       pendingCommandMetrics.push(metric)
+      return
+    }
+
+    // A typo fires command-not-found, then the host rethrows it as command-error; drop that rethrow.
+    if (eventType === 'command-not-found') {
+      commandNotFoundFired = true
+    } else if (eventType === 'command-error' && commandNotFoundFired) {
+      commandNotFoundFired = false
+      debug('dropping command-error that rethrows a command-not-found (same typo)')
       return
     }
 
@@ -262,12 +273,15 @@ async function trackEvent (eventType, rawEventData = {}) {
  */
 function trackPrerun (command, flags, start) {
   prerunEvent = { command, flags, start }
+  // A real command is now running (e.g. an accepted "did you mean" suggestion), so its errors count.
+  commandNotFoundFired = false
 }
 
 module.exports = {
   getInvocationContext,
   init: (versionString, binName, remoteConf = {}) => {
     pendingCommandMetrics.length = 0
+    commandNotFoundFired = false
     global.commandHookStartTime = Date.now()
     rootCliVersion = versionString
     postUrl = remoteConf.postUrl || process.env.AIO_TELEMETRY_POST_URL || DEFAULT_TELEMETRY_POST_URL

--- a/src/telemetry-lib.js
+++ b/src/telemetry-lib.js
@@ -26,8 +26,11 @@ function isEnvTelemetryDisabled () {
 
 let isDisabledForCommand = false
 
-/** Metrics for non-`postrun` events in the current command; merged into one POST on `postrun`. */
+/** Metrics for non-terminal events in the current command; merged into the POST on a terminal event. */
 const pendingCommandMetrics = []
+
+/** Events after which oclif does not run `postrun`; each triggers an immediate flush. */
+const TERMINAL_EVENTS = ['postrun', 'command-error', 'command-not-found']
 
 /**
  * Detects GitHub Copilot Chat on PATH via the extension id in globalStorage paths (any OS path separator).
@@ -173,9 +176,10 @@ function formatEventDataAttribute (eventData) {
 }
 
 /**
- * Records a telemetry event. Non-`postrun` metrics are held in memory and sent in a single
- * batched POST when `postrun` runs. When enabled, the flush worker is detached so the CLI
- * never waits on the network; failed deliveries are dropped (no disk queue).
+ * Records a telemetry event. Non-terminal metrics are held in memory and sent in a single
+ * batched POST on the next terminal event (`postrun`, `command-error`, `command-not-found`).
+ * When enabled, the flush worker is detached so the CLI never waits on the network; failed
+ * deliveries are dropped (no disk queue).
  *
  * @param {string} eventType prerun, postrun, command-error, command-not-found, telemetry
  * @param {object|string|number|undefined} [rawEventData] Optional hook payload (e.g. `{ message }` on errors).
@@ -219,7 +223,12 @@ async function trackEvent (eventType, rawEventData = {}) {
       }
     }
 
-    if (eventType !== 'postrun') {
+    // `postrun` fires after a command completes successfully. `command-error` and
+    // `command-not-found` are *terminal*: oclif does NOT run `postrun` after them, so if we
+    // only flushed on `postrun` these (the most valuable signal) would be buffered and silently
+    // dropped on exit. Flush on any terminal event so error telemetry is actually delivered.
+    const isTerminalEvent = TERMINAL_EVENTS.includes(eventType)
+    if (!isTerminalEvent) {
       pendingCommandMetrics.push(metric)
       return
     }

--- a/src/telemetry-lib.js
+++ b/src/telemetry-lib.js
@@ -214,7 +214,9 @@ async function trackEvent (eventType, rawEventData = {}) {
       value: 1,
       timestamp,
       attributes: {
-        eventType,
+        // NB: the wire attribute is `eventName`, not `eventType` — `eventType` is a New Relic
+        // reserved word and is dropped on Metric API ingest, so it is unqueryable in NRQL.
+        eventName: eventType,
         eventData: formatEventDataAttribute(eventData),
         cliVersion: rootCliVersion,
         clientId,

--- a/test/flush-worker.test.js
+++ b/test/flush-worker.test.js
@@ -16,7 +16,7 @@ const fetch = createFetch()
 const { main } = require('../src/flush-worker')
 
 const PROXY = 'https://telemetry-proxy.example/api/v1/web/dx-excshell-1/telemetry'
-const METRIC = { name: 'aio.cli.telemetry', type: 'gauge', value: 1, timestamp: 1000, attributes: { eventType: 'postrun' } }
+const METRIC = { name: 'aio.cli.telemetry', type: 'gauge', value: 1, timestamp: 1000, attributes: { eventName: 'postrun' } }
 const BODY = JSON.stringify([{ metrics: [METRIC] }])
 const flushArg = (body = BODY, extraHeaders) => {
   const base = { body, postUrl: PROXY }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -41,32 +41,31 @@ describe('hook interfaces', () => {
     noticeSpy.mockRestore()
   })
 
-  test('command-error', async () => {
+  // oclif does not run `postrun` after a command throws, so the error hook itself must flush.
+  test('command-error flushes immediately (no postrun follows an error)', async () => {
     config.get.mockImplementation((key) => (String(key).includes('optOut') ? false : 'clientid'))
     telemetryLib.init('name@0.0.1', 'aio', mockPackageJson.aioTelemetry)
     const hook = require('../src/hooks/command-error')
     expect(typeof hook).toBe('function')
     await hook({ message: 'msg' })
-    expect(spawn).not.toHaveBeenCalled()
-    await telemetryLib.trackEvent('postrun')
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     const body = JSON.parse(flushPayload.body)
-    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error', 'postrun'])
+    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+    expect(body[0].metrics[0].attributes.commandSuccess).toBe(false)
   })
 
-  test('command-not-found', async () => {
+  // command-not-found is terminal too: no command runs, so no postrun.
+  test('command-not-found flushes immediately', async () => {
     config.get.mockImplementation((key) => (String(key).includes('optOut') ? false : 'clientid'))
     telemetryLib.init('name@0.0.1', 'aio', mockPackageJson.aioTelemetry)
     const hook = require('../src/hooks/command-not-found')
     expect(typeof hook).toBe('function')
     await hook({ id: 'id' })
-    expect(spawn).not.toHaveBeenCalled()
-    await telemetryLib.trackEvent('postrun')
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayloadNf = JSON.parse(spawn.mock.calls[0][1][1])
     const bodyNf = JSON.parse(flushPayloadNf.body)
-    expect(bodyNf[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found', 'postrun'])
+    expect(bodyNf[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
   })
 
   test('init shows one-time notice on first run', async () => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -66,6 +66,7 @@ describe('hook interfaces', () => {
     const flushPayloadNf = JSON.parse(spawn.mock.calls[0][1][1])
     const bodyNf = JSON.parse(flushPayloadNf.body)
     expect(bodyNf[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
+    expect(bodyNf[0].metrics[0].attributes.commandSuccess).toBe(false)
   })
 
   test('init shows one-time notice on first run', async () => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -51,7 +51,7 @@ describe('hook interfaces', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     const body = JSON.parse(flushPayload.body)
-    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+    expect(body[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-error'])
     expect(body[0].metrics[0].attributes.commandSuccess).toBe(false)
   })
 
@@ -65,7 +65,7 @@ describe('hook interfaces', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayloadNf = JSON.parse(spawn.mock.calls[0][1][1])
     const bodyNf = JSON.parse(flushPayloadNf.body)
-    expect(bodyNf[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
+    expect(bodyNf[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-not-found'])
     expect(bodyNf[0].metrics[0].attributes.commandSuccess).toBe(false)
   })
 
@@ -83,7 +83,7 @@ describe('hook interfaces', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayloadAcc = JSON.parse(spawn.mock.calls[0][1][1])
     const bodyAcc = JSON.parse(flushPayloadAcc.body)
-    expect(bodyAcc[0].metrics.map((m) => m.attributes.eventType)).toEqual(['telemetry-notice', 'postrun'])
+    expect(bodyAcc[0].metrics.map((m) => m.attributes.eventName)).toEqual(['telemetry-notice', 'postrun'])
     expect(bodyAcc[0].metrics[0].attributes.eventData).toBe('shown')
     process.env = preEnv
   })
@@ -158,7 +158,7 @@ describe('hook interfaces', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayloadCe = JSON.parse(spawn.mock.calls[0][1][1])
     const bodyCe = JSON.parse(flushPayloadCe.body)
-    expect(bodyCe[0].metrics.map((m) => m.attributes.eventType)).toEqual(['telemetry-custom-event', 'postrun'])
+    expect(bodyCe[0].metrics.map((m) => m.attributes.eventName)).toEqual(['telemetry-custom-event', 'postrun'])
   })
 
   test('postrun', async () => {
@@ -170,7 +170,7 @@ describe('hook interfaces', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     expect(flushPayload.headers).toBeUndefined()
-    expect(flushPayload.body).toContain('"eventType":"postrun"')
+    expect(flushPayload.body).toContain('"eventName":"postrun"')
   })
 
   /**

--- a/test/telemetry-lib.test.js
+++ b/test/telemetry-lib.test.js
@@ -94,6 +94,63 @@ describe('telemetry-lib', () => {
     expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['telemetry-custom-event', 'command-error'])
   })
 
+  test('a typo (command-not-found then host command-error) is recorded as a single command-not-found', async () => {
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binOnce', {})
+    // a typo fires command-not-found (from oclif) and then command-error (rethrown by the host)
+    await telemetryLib.trackEvent('command-not-found', 'bogus')
+    await telemetryLib.trackEvent('command-error', { message: 'Run aio help' })
+    expect(spawn).toHaveBeenCalledTimes(1)
+    const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
+    const body = JSON.parse(flushPayload.body)
+    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
+  })
+
+  test('only the first command-error after a not-found is suppressed; a later one still flushes', async () => {
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binReset', {})
+    await telemetryLib.trackEvent('command-not-found', 'bogus') // flush #1
+    await telemetryLib.trackEvent('command-error', { message: 'Run aio help' }) // dropped: the typo rethrow
+    await telemetryLib.trackEvent('command-error', { message: 'unrelated later error' }) // flush #2
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+  })
+
+  test('"Did you mean ...? Yes": not-found then the suggested command runs and its postrun flushes', async () => {
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binYes', {})
+    await telemetryLib.trackEvent('command-not-found', 'telemetryd') // flush #1
+    telemetryLib.trackPrerun('telemetry', [], Date.now()) // suggestion accepted -> command runs
+    await telemetryLib.trackEvent('postrun') // flush #2
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['postrun'])
+  })
+
+  test('"Did you mean ...? Yes" then the suggested command errors: that command-error is NOT masked', async () => {
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binYesErr', {})
+    await telemetryLib.trackEvent('command-not-found', 'telemetryd') // flush #1
+    telemetryLib.trackPrerun('telemetry', [], Date.now()) // suggestion accepted -> command runs (clears the flag)
+    await telemetryLib.trackEvent('command-error', { message: 'the real command failed' }) // flush #2
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+  })
+
+  test('nested commands in one process each flush (no masking): two postruns => two flushes', async () => {
+    // A command that calls config.runCommand re-fires prerun/postrun for the child; init runs once.
+    // The child postrun must NOT suppress the parent terminal event.
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binNested', {})
+    telemetryLib.trackPrerun('app:clean', [], Date.now())
+    await telemetryLib.trackEvent('postrun') // child (e.g. app:clean) succeeds
+    telemetryLib.trackPrerun('app:undeploy', [], Date.now())
+    await telemetryLib.trackEvent('command-error', { message: 'parent failed after child succeeded' })
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['postrun'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+  })
+
   test('postrun adds durationMs to eventData when the hook omits payload and prerunTimer is set', async () => {
     global.prerunTimer = Date.now() - 40
     config.get.mockReturnValue('clientidxyz')

--- a/test/telemetry-lib.test.js
+++ b/test/telemetry-lib.test.js
@@ -82,6 +82,18 @@ describe('telemetry-lib', () => {
     expect(body[0].metrics[1].attributes.eventType).toBe('postrun')
   })
 
+  test('terminal command-error flushes buffered events without a postrun', async () => {
+    config.get.mockReturnValue('clientidxyz')
+    telemetryLib.init('a@4', 'binErr', {})
+    await telemetryLib.trackEvent('telemetry-custom-event')
+    expect(spawn).not.toHaveBeenCalled()
+    await telemetryLib.trackEvent('command-error', { message: 'boom' })
+    expect(spawn).toHaveBeenCalledTimes(1)
+    const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
+    const body = JSON.parse(flushPayload.body)
+    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['telemetry-custom-event', 'command-error'])
+  })
+
   test('postrun adds durationMs to eventData when the hook omits payload and prerunTimer is set', async () => {
     global.prerunTimer = Date.now() - 40
     config.get.mockReturnValue('clientidxyz')

--- a/test/telemetry-lib.test.js
+++ b/test/telemetry-lib.test.js
@@ -78,8 +78,8 @@ describe('telemetry-lib', () => {
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     const body = JSON.parse(flushPayload.body)
     expect(body[0].metrics).toHaveLength(2)
-    expect(body[0].metrics[0].attributes.eventType).toBe('telemetry-custom-event')
-    expect(body[0].metrics[1].attributes.eventType).toBe('postrun')
+    expect(body[0].metrics[0].attributes.eventName).toBe('telemetry-custom-event')
+    expect(body[0].metrics[1].attributes.eventName).toBe('postrun')
   })
 
   test('terminal command-error flushes buffered events without a postrun', async () => {
@@ -91,7 +91,7 @@ describe('telemetry-lib', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     const body = JSON.parse(flushPayload.body)
-    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['telemetry-custom-event', 'command-error'])
+    expect(body[0].metrics.map((m) => m.attributes.eventName)).toEqual(['telemetry-custom-event', 'command-error'])
   })
 
   test('a typo (command-not-found then host command-error) is recorded as a single command-not-found', async () => {
@@ -103,7 +103,7 @@ describe('telemetry-lib', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     const flushPayload = JSON.parse(spawn.mock.calls[0][1][1])
     const body = JSON.parse(flushPayload.body)
-    expect(body[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
+    expect(body[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-not-found'])
   })
 
   test('only the first command-error after a not-found is suppressed; a later one still flushes', async () => {
@@ -113,8 +113,8 @@ describe('telemetry-lib', () => {
     await telemetryLib.trackEvent('command-error', { message: 'Run aio help' }) // dropped: the typo rethrow
     await telemetryLib.trackEvent('command-error', { message: 'unrelated later error' }) // flush #2
     expect(spawn).toHaveBeenCalledTimes(2)
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-not-found'])
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-not-found'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-error'])
   })
 
   test('"Did you mean ...? Yes": not-found then the suggested command runs and its postrun flushes', async () => {
@@ -124,7 +124,7 @@ describe('telemetry-lib', () => {
     telemetryLib.trackPrerun('telemetry', [], Date.now()) // suggestion accepted -> command runs
     await telemetryLib.trackEvent('postrun') // flush #2
     expect(spawn).toHaveBeenCalledTimes(2)
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['postrun'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['postrun'])
   })
 
   test('"Did you mean ...? Yes" then the suggested command errors: that command-error is NOT masked', async () => {
@@ -134,7 +134,7 @@ describe('telemetry-lib', () => {
     telemetryLib.trackPrerun('telemetry', [], Date.now()) // suggestion accepted -> command runs (clears the flag)
     await telemetryLib.trackEvent('command-error', { message: 'the real command failed' }) // flush #2
     expect(spawn).toHaveBeenCalledTimes(2)
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-error'])
   })
 
   test('nested commands in one process each flush (no masking): two postruns => two flushes', async () => {
@@ -147,8 +147,8 @@ describe('telemetry-lib', () => {
     telemetryLib.trackPrerun('app:undeploy', [], Date.now())
     await telemetryLib.trackEvent('command-error', { message: 'parent failed after child succeeded' })
     expect(spawn).toHaveBeenCalledTimes(2)
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['postrun'])
-    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventType)).toEqual(['command-error'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[0][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['postrun'])
+    expect(JSON.parse(JSON.parse(spawn.mock.calls[1][1][1]).body)[0].metrics.map((m) => m.attributes.eventName)).toEqual(['command-error'])
   })
 
   test('postrun adds durationMs to eventData when the hook omits payload and prerunTimer is set', async () => {


### PR DESCRIPTION
## Description

`command-error` / `command-not-found` telemetry was buffered and silently dropped: the batched flush only ran on `postrun`, which oclif doesn't run after an error or a not-found command. This restores delivery of error telemetry.

### Changes
  - **Flush on any terminal event** (`postrun`, `command-error`, `command-not-found`) instead of only `postrun`.
  - **De-dupe the typo path:** a not-found fires `command-not-found` and then the host rethrows it as `command-error`; drop that one rethrow. Scoped narrowly (and cleared on `prerun`) so nested
  `config.runCommand` and "Did you mean…? Yes" don't get masked.
  - **`command-not-found` is now `commandSuccess: false`** (a missing command didn't succeed).
  - Send `eventType` as `eventName` in the attributes, as the former is a reserved name in New Relic (see [this](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/))

  ## Related Issue

  Flagged in code review on PR #39 (`src/telemetry-lib.js`)

  ## How Has This Been Tested?

- Unit tests, 100% coverage, lint clean (one pre-existing test fails only inside an AI-agent shell — passes in CI).
- Verified end-to-end against the prod proxy / New Relic: real errors and typos each deliver a single correct event; nested commands each flush (no masking).

  ## Screenshots (if appropriate):

<img width="1661" height="397" alt="image" src="https://github.com/user-attachments/assets/1779d3f1-0b99-409b-b32e-dcc2f33f147f" />

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.